### PR TITLE
Use new dry-validation methods

### DIFF
--- a/lib/formalist/rich_text/embedded_form_compiler.rb
+++ b/lib/formalist/rich_text/embedded_form_compiler.rb
@@ -79,7 +79,7 @@ module Formalist
         # fully)
         input = embedded_form.input_processor.(validation.to_h)
 
-        embedded_form.form.fill(input: input, errors: validation.messages).to_ast
+        embedded_form.form.fill(input: input, errors: validation.errors.to_h).to_ast
       end
     end
   end

--- a/spec/integration/form_spec.rb
+++ b/spec/integration/form_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Formalist::Form do
   }
 
   it "outputs an AST" do
-    form = form_class.new.fill(input: input, errors: schema.(input).messages)
+    form = form_class.new.fill(input: input, errors: schema.(input).errors.to_h)
 
     expect(form.to_ast).to eq [
       [:compound_field, [


### PR DESCRIPTION
This PR adjusts the embedded form compiler to use the new `errors` method instead of `messages`.

Not sure if we want to support both methods or require a specific version of dry-validation.