### PR TITLE
Adding metadata to form and elements for dynamic attributes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :test do
   gem "codeclimate-test-reporter", require: nil
   gem "dry-auto_inject"
-  gem "dry-validation"
+  gem "dry-validation", "~> 1.0"
 end
 
 group :tools do

--- a/lib/formalist/element.rb
+++ b/lib/formalist/element.rb
@@ -6,7 +6,7 @@ module Formalist
     extend ClassInterface
 
     # @api private
-    attr_reader :name, :attributes, :children, :input, :errors
+    attr_reader :name, :attributes, :children, :input, :errors, :meta
 
     # @api private
     def self.build(**args)
@@ -14,12 +14,12 @@ module Formalist
     end
 
     # @api private
-    def self.fill(input: {}, errors: {}, **args)
+    def self.fill(input: {}, errors: {}, meta: {}, **args)
       new(args).fill(input: input, errors: errors)
     end
 
     # @api private
-    def initialize(name: nil, attributes: {}, children: [], input: nil, errors: [])
+    def initialize(name: nil, attributes: {}, children: [], input: nil, errors: [], meta: {})
       @name = name&.to_sym
 
       @attributes = self.class.attributes_schema.each_with_object({}) { |(name, defn), hsh|
@@ -30,10 +30,11 @@ module Formalist
       @children = children
       @input = input
       @errors = errors
+      @meta = meta
     end
 
-    def fill(input: {}, errors: {}, **args)
-      return self if input == @input && errors == @errors
+    def fill(input: {}, errors: {}, meta: {}, **args)
+      return self if input == @input && errors == @errors && @meta == meta
 
       args = {
         name: @name,
@@ -41,6 +42,7 @@ module Formalist
         children: @children,
         input: input,
         errors: errors,
+        meta: meta,
       }.merge(args)
 
       self.class.new(args)

--- a/lib/formalist/element/attributes.rb
+++ b/lib/formalist/element/attributes.rb
@@ -2,13 +2,14 @@ module Formalist
   class Element
     class Attributes
       # Returns the attributes hash.
-      attr_reader :attrs
+      attr_reader :attrs, :meta
 
       # Creates an attributes object from the supplied hash.
       #
       # @param attrs [Hash] hash of form element attributes
-      def initialize(attrs = {})
+      def initialize(attrs = {}, meta: {})
         @attrs = attrs
+        @meta = meta
       end
 
       # Returns the attributes as an abstract syntax tree.
@@ -28,6 +29,8 @@ module Formalist
             [:array, value.map { |v| deep_to_ast(v) }]
           when String, Numeric, TrueClass, FalseClass, NilClass
             [:value, [value]]
+          when Proc
+            deep_to_ast(value.call(meta))
           else
             [:value, [value.to_s]]
         end
@@ -41,6 +44,8 @@ module Formalist
             value.map { |v| deep_simplify(v) }
           when String, Numeric, TrueClass, FalseClass, NilClass
             value
+          when Proc
+            deep_simplify(value.call(meta))
           else
             if value.respond_to?(:to_h)
               deep_simplify(value.to_h)

--- a/lib/formalist/elements/attr.rb
+++ b/lib/formalist/elements/attr.rb
@@ -5,15 +5,15 @@ module Formalist
     class Attr < Element
       attribute :label
 
-      def fill(input:, errors:)
+      def fill(input:, errors:, meta: {})
         input = input[name] || {}
         errors = errors[name] || {}
 
         children = self.children.map { |child|
-          child.fill(input: input, errors: errors)
+          child.fill(input: input, errors: errors, meta: meta)
         }
 
-        super(input: input, errors: errors, children: children)
+        super(input: input, errors: errors, meta: meta, children: children)
       end
 
       # Converts the attribute into an abstract syntax tree.
@@ -52,7 +52,7 @@ module Formalist
           name,
           type,
           local_errors,
-          Element::Attributes.new(attributes).to_ast,
+          Element::Attributes.new(attributes, meta: meta).to_ast,
           children.map(&:to_ast),
         ]]
       end

--- a/lib/formalist/elements/compound_field.rb
+++ b/lib/formalist/elements/compound_field.rb
@@ -3,12 +3,12 @@ require "formalist/element"
 module Formalist
   class Elements
     class CompoundField < Element
-      def fill(input: {}, errors: {})
+      def fill(input: {}, errors: {}, meta: {})
         children = self.children.map { |child|
-          child.fill(input: input, errors: errors)
+          child.fill(input: input, errors: errors, meta: meta)
         }
 
-        super(input: input, errors: errors, children: children)
+        super(input: input, errors: errors, meta: meta, children: children)
       end
 
       # Converts the compound field into an abstract syntax tree.
@@ -40,7 +40,7 @@ module Formalist
       def to_ast
         [:compound_field, [
           type,
-          Element::Attributes.new(attributes).to_ast,
+          Element::Attributes.new(attributes, meta: meta).to_ast,
           children.map(&:to_ast),
         ]]
       end

--- a/lib/formalist/elements/field.rb
+++ b/lib/formalist/elements/field.rb
@@ -9,10 +9,11 @@ module Formalist
       attribute :inline
       attribute :validation
 
-      def fill(input: {}, errors: {})
+      def fill(input: {}, errors: {}, meta: {})
         super(
           input: input[name],
           errors: errors[name].to_a,
+          meta: meta,
         )
       end
 
@@ -54,7 +55,7 @@ module Formalist
           type,
           input,
           errors,
-          Element::Attributes.new(attributes).to_ast,
+          Element::Attributes.new(attributes, meta: meta).to_ast,
         ]]
       end
     end

--- a/lib/formalist/elements/group.rb
+++ b/lib/formalist/elements/group.rb
@@ -5,12 +5,12 @@ module Formalist
     class Group < Element
       attribute :label
 
-      def fill(input: {}, errors: {})
+      def fill(input: {}, errors: {}, meta: {})
         children = self.children.map { |child|
-          child.fill(input: input, errors: errors)
+          child.fill(input: input, errors: errors, meta: meta)
         }
 
-        super(input: input, errors: errors, children: children)
+        super(input: input, errors: errors, meta: meta, children: children)
       end
 
       # Converts the group into an abstract syntax tree.
@@ -41,7 +41,7 @@ module Formalist
       def to_ast
         [:group, [
           type,
-          Element::Attributes.new(attributes).to_ast,
+          Element::Attributes.new(attributes, meta: meta).to_ast,
           children.map(&:to_ast),
         ]]
       end

--- a/lib/formalist/elements/many.rb
+++ b/lib/formalist/elements/many.rb
@@ -26,7 +26,7 @@ module Formalist
       end
 
       # @api private
-      def fill(input: {}, errors: {})
+      def fill(input: {}, errors: {}, meta: {})
         input = input.fetch(name) { [] }
         errors = errors.fetch(name) { {} }
 
@@ -36,12 +36,13 @@ module Formalist
         children = input.each_with_index.map { |child_input, index|
           child_errors = errors.is_a?(Hash) ? errors.fetch(index) { {} } : {}
 
-          child_template.map { |child| child.fill(input: child_input, errors: child_errors) }
+          child_template.map { |child| child.fill(input: child_input, errors: child_errors, meta: meta) }
         }
 
         super(
           input: input,
           errors: errors,
+          meta: meta,
           children: children,
           child_template: child_template,
         )
@@ -117,7 +118,7 @@ module Formalist
           name,
           type,
           local_errors,
-          Element::Attributes.new(attributes).to_ast,
+          Element::Attributes.new(attributes, meta: meta).to_ast,
           child_template.map(&:to_ast),
           children.map { |el_list| el_list.map(&:to_ast) },
         ]]

--- a/lib/formalist/elements/section.rb
+++ b/lib/formalist/elements/section.rb
@@ -5,11 +5,12 @@ module Formalist
     class Section < Element
       attribute :label
 
-      def fill(input: {}, errors: {})
+      def fill(input: {}, errors: {}, meta: {})
         super(
           input: input,
           errors: errors,
-          children: children.map { |child| child.fill(input: input, errors: errors) },
+          meta: meta,
+          children: children.map { |child| child.fill(input: input, errors: errors, meta: meta) },
         )
       end
 
@@ -44,7 +45,7 @@ module Formalist
         [:section, [
           name,
           type,
-          Element::Attributes.new(attributes).to_ast,
+          Element::Attributes.new(attributes, meta: meta).to_ast,
           children.map(&:to_ast),
         ]]
       end

--- a/lib/formalist/form.rb
+++ b/lib/formalist/form.rb
@@ -21,11 +21,13 @@ module Formalist
     attr_reader :elements
     attr_reader :input
     attr_reader :errors
+    attr_reader :meta
     attr_reader :dependencies
 
-    def initialize(elements: Undefined, input: {}, errors: {}, **dependencies)
+    def initialize(elements: Undefined, input: {}, errors: {}, meta: {}, **dependencies)
       @input = input
       @errors = errors
+      @meta = meta
 
       @elements =
         if elements == Undefined
@@ -37,11 +39,11 @@ module Formalist
       @dependencies = dependencies
     end
 
-    def fill(input: {}, errors: {})
-      return self if input == @input && errors == @errors
+    def fill(input: {}, errors: {}, meta: {})
+      return self if input == @input && errors == @errors && meta == @meta
 
       self.class.new(
-        elements: @elements.map { |element| element.fill(input: input, errors: errors) },
+        elements: @elements.map { |element| element.fill(input: input, errors: errors, meta: meta) },
         input: input,
         errors: errors,
         **@dependencies,
@@ -53,6 +55,7 @@ module Formalist
         elements: @elements,
         input: @input,
         errors: @errors,
+        meta: @meta,
         **@dependencies.merge(new_dependencies)
       )
     end

--- a/lib/formalist/rich_text/embedded_form_compiler.rb
+++ b/lib/formalist/rich_text/embedded_form_compiler.rb
@@ -79,7 +79,7 @@ module Formalist
         # fully)
         input = embedded_form.input_processor.(validation.to_h)
 
-        embedded_form.form.fill(input: input, errors: validation.messages).to_ast
+        embedded_form.form.fill(input: input, errors: validation.errors).to_ast
       end
     end
   end

--- a/spec/integration/form_spec.rb
+++ b/spec/integration/form_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Formalist::Form do
     Class.new(Formalist::Form) do
       define do
         compound_field do
-          field :title, validate: {filled: true}
+          field :title, validate: {filled: true}, hint: -> (meta) { "In #{meta[:language]}" }
           field :rating, validate: {filled: true}
         end
 
@@ -60,14 +60,14 @@ RSpec.describe Formalist::Form do
   }
 
   it "outputs an AST" do
-    form = form_class.new.fill(input: input, errors: contract.(input).errors)
+    form = form_class.new.fill(input: input, errors: contract.(input).errors, meta: {language: "English"})
 
     expect(form.to_ast).to eq [
       [:compound_field, [
         :compound_field,
         [:object, []],
         [
-          [:field, [:title, :field, "Aurora", [], [:object, []]]],
+          [:field, [:title, :field, "Aurora", [], [:object, [[:hint, [:value, ["In English"]]]]]]],
           [:field, [:rating, :field, "10", ["must be an integer"], [:object, []]]]
         ]
       ]],

--- a/spec/integration/form_spec.rb
+++ b/spec/integration/form_spec.rb
@@ -1,18 +1,22 @@
+require "dry/validation/contract"
+
 RSpec.describe Formalist::Form do
-  let(:schema) {
-    Dry::Validation.Schema do
-      required(:title).filled
-      required(:rating).filled(:int?)
+  let(:contract) {
+    Class.new(Dry::Validation::Contract) do
+      schema do
+        required(:title).filled(:string)
+        required(:rating).filled(:integer)
 
-      required(:reviews).each do
-        required(:summary).filled
-        required(:rating).filled(:int?, gteq?: 1, lteq?: 10)
-      end
+        required(:reviews).array(:hash) do
+          required(:summary).filled(:string)
+          required(:rating).filled(:integer, gteq?: 1, lteq?: 10)
+        end
 
-      required(:meta).schema do
-        required(:pages).filled(:int?, gteq?: 1)
+        required(:meta).hash do
+          required(:pages).filled(:integer, gteq?: 1)
+        end
       end
-    end
+    end.new
   }
 
   subject(:form_class) {
@@ -56,7 +60,7 @@ RSpec.describe Formalist::Form do
   }
 
   it "outputs an AST" do
-    form = form_class.new.fill(input: input, errors: schema.(input).messages)
+    form = form_class.new.fill(input: input, errors: contract.(input).errors)
 
     expect(form.to_ast).to eq [
       [:compound_field, [
@@ -88,7 +92,7 @@ RSpec.describe Formalist::Form do
           ],
           [
             [:field, [:summary, :field, "Great!", [], [:object, []]]],
-            [:field, [:rating, :field, 0, ["must be greater than or equal to 1", "must be less than or equal to 10"], [:object, []]]]
+            [:field, [:rating, :field, 0, ["must be greater than or equal to 1"], [:object, []]]]
           ]
         ]
       ]],

--- a/spec/unit/rich_text/embedded_form_compiler_spec.rb
+++ b/spec/unit/rich_text/embedded_form_compiler_spec.rb
@@ -1,4 +1,4 @@
-require "dry-validation"
+require "dry/schema"
 require "formalist/form"
 require "formalist/elements/standard"
 require "formalist/rich_text/embedded_forms_container"
@@ -23,9 +23,9 @@ RSpec.describe Formalist::RichText::EmbeddedFormCompiler do
   }
 
   let(:schema) {
-    Dry::Validation.Params do
-      required(:image_id).filled(:int?)
-      required(:caption).filled(:str?)
+    Dry::Schema.Params do
+      required(:image_id).filled(:integer)
+      required(:caption).filled(:string)
     end
   }
 
@@ -67,7 +67,7 @@ RSpec.describe Formalist::RichText::EmbeddedFormCompiler do
     }
 
     it "builds a form AST with the data and validation messages incorporated" do
-      expect(output[1]).to eq ["block", ["atomic", "48b4f", [["entity", ["formalist", "1", "IMMUTABLE", {"name" => "image_with_caption", "label" => "Image with caption", "data" => {"image_id" => "", "caption" => "Large panda"}, "form" => [[:field, [:image_id, :text_field, nil, ["must be filled"], [:object, []]]], [:field, [:caption, :text_field, "Large panda", [], [:object, []]]]]}, [["inline", [[], "¶"]]]]]]]]
+      expect(output[1]).to eq ["block", ["atomic", "48b4f", [["entity", ["formalist", "1", "IMMUTABLE", {"name" => "image_with_caption", "label" => "Image with caption", "data" => {"image_id" => "", "caption" => "Large panda"}, "form" => [[:field, [:image_id, :text_field, "", ["must be filled"], [:object, []]]], [:field, [:caption, :text_field, "Large panda", [], [:object, []]]]]}, [["inline", [[], "¶"]]]]]]]]
     end
 
     it "leaves the rest of the data unchanged" do


### PR DESCRIPTION
This addresses #89 in what feels to be a simple manner (and I'm very open to changing approaches). The meta object here is presumed to be a hash, but isn’t considered to match the nested structure of elements/fields (unlike errors and inputs), hence there’s no digging through its structure as part of the rendering process.

It’s combined with the ability to pass procs through as attribute values, and when rendering they get invoked with a single argument - the meta object. And arguably there’s nothing stopping meta from being something other than a hash too. Entirely up to the consumer.

(I realise 829ae93ebeb4ab1c5791316bdff66503b25f7c48 is included here, because that's the branch we're working with, but it's completely unrelated to the focus of the PR.)