### PR TITLE
Add namespace and paths options to embedded form renderer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :test do
   gem "codeclimate-test-reporter", require: nil
   gem "dry-auto_inject"
-  gem "dry-validation"
+  gem "dry-validation", "~> 1.0"
 end
 
 group :tools do

--- a/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
+++ b/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
@@ -3,21 +3,39 @@ module Formalist
     module Rendering
       class EmbeddedFormRenderer
         attr_reader :container
+        attr_reader :namespace
+        attr_reader :paths
         attr_reader :options
 
-        def initialize(container = {}, **options)
+        def initialize(container = {}, namespace: nil, paths: [], **options)
           @container = container
+          @namespace = namespace
+          @paths = paths
           @options = options
         end
 
         def call(form_data)
           type, data = form_data.values_at(:name, :data)
 
-          if container.key?(type)
-            container[type].(data, options)
+          key = resolve_key(type)
+
+          if key
+            container[key].(data, options)
           else
             ""
           end
+        end
+
+        private
+
+        def resolve_key(type)
+          paths.each do |path|
+            path_key = path.tr("/", ".")
+            key = [namespace, path_key, type].compact.join(".")
+            return key if container.key?(key)
+          end
+          key =  [namespace, type].compact.join(".")
+          return key if container.key?(key)
         end
       end
     end

--- a/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
+++ b/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
@@ -34,7 +34,8 @@ module Formalist
             key = [namespace, path_key, type].compact.join(".")
             return key if container.key?(key)
           end
-          key =  [namespace, type].compact.join(".")
+
+          key = [namespace, type].compact.join(".")
           return key if container.key?(key)
         end
       end

--- a/spec/unit/rich_text/embedded_form_compiler_spec.rb
+++ b/spec/unit/rich_text/embedded_form_compiler_spec.rb
@@ -1,4 +1,4 @@
-require "dry-validation"
+require "dry/schema"
 require "formalist/form"
 require "formalist/elements/standard"
 require "formalist/rich_text/embedded_forms_container"
@@ -23,9 +23,9 @@ RSpec.describe Formalist::RichText::EmbeddedFormCompiler do
   }
 
   let(:schema) {
-    Dry::Validation.Params do
-      required(:image_id).filled(:int?)
-      required(:caption).filled(:str?)
+    Dry::Schema.Params do
+      required(:image_id).filled(:integer)
+      required(:caption).filled(:string)
     end
   }
 
@@ -67,7 +67,7 @@ RSpec.describe Formalist::RichText::EmbeddedFormCompiler do
     }
 
     it "builds a form AST with the data and validation messages incorporated" do
-      expect(output[1]).to eq ["block", ["atomic", "48b4f", [["entity", ["formalist", "1", "IMMUTABLE", {"name" => "image_with_caption", "label" => "Image with caption", "data" => {"image_id" => "", "caption" => "Large panda"}, "form" => [[:field, [:image_id, :text_field, nil, ["must be filled"], [:object, []]]], [:field, [:caption, :text_field, "Large panda", [], [:object, []]]]]}, [["inline", [[], "¶"]]]]]]]]
+      expect(output[1]).to eq ["block", ["atomic", "48b4f", [["entity", ["formalist", "1", "IMMUTABLE", {"name" => "image_with_caption", "label" => "Image with caption", "data" => {"image_id" => "", "caption" => "Large panda"}, "form" => [[:field, [:image_id, :text_field, "", ["must be filled"], [:object, []]]], [:field, [:caption, :text_field, "Large panda", [], [:object, []]]]]}, [["inline", [[], "¶"]]]]]]]]
     end
 
     it "leaves the rest of the data unchanged" do

--- a/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
+++ b/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
@@ -1,0 +1,71 @@
+require "formalist/rich_text/rendering/embedded_form_renderer"
+
+RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
+  subject(:renderer) { described_class.new(container, namespace: namespace, paths: paths) }
+
+  let(:container) {{
+    "article" => "top_level_article",
+    "embedded_forms.article" => "namespaced_article",
+    "embedded_forms.newsletter.article" => "newsletter_article",
+    "embedded_forms.newsletter.components.article" => "newsletter_components_article",
+    "embedded_forms.general.article" => "general_article",
+   }}
+
+  context "no namespace or paths configured" do
+    let(:namespace) { nil }
+    let(:paths) { [] }
+
+    describe "#resolve_key" do
+      it "returns the top level result" do
+        expect(renderer.send(:resolve_key, "article")).to eq "article"
+      end
+    end
+  end
+
+  context "namespace configured" do
+    let(:namespace) { "embedded_forms" }
+    let(:paths) { [] }
+
+    describe "#resolve_key" do
+      it "returns the namespaced result" do
+        expect(renderer.send(:resolve_key, "article")).to eq "embedded_forms.article"
+      end
+    end
+  end
+
+  context "namespace and paths configured" do
+    let(:namespace) { "embedded_forms" }
+    let(:paths) { ["newsletter/components", "newsletter", "general"] }
+
+    describe "#resolve_key" do
+      it "returns the result in the first path" do
+        expect(renderer.send(:resolve_key, "article")).to eq "embedded_forms.newsletter.components.article"
+      end
+    end
+  end
+
+  context "key not in paths" do
+    let(:namespace) { "embedded_forms" }
+    let(:paths) { ["other", "path"] }
+
+    describe "#resolve_key" do
+      it "returns the result in the namespace" do
+        expect(renderer.send(:resolve_key, "article")).to eq "embedded_forms.article"
+      end
+    end
+  end
+
+  context "key not in namespace" do
+    let(:namespace) { "embedded_forms" }
+    let(:paths) { ["other", "path"] }
+    let(:container) {{
+      "article" => "top_level_article"
+     }}
+
+    describe "#resolve_key" do
+      it "does not return the result outside the namespace" do
+        expect(renderer.send(:resolve_key, "article")).to eq nil
+      end
+    end
+  end
+end

--- a/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
+++ b/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
@@ -4,34 +4,32 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
   subject(:renderer) { described_class.new(container, namespace: namespace, paths: paths) }
 
   let(:container) {{
-    "article" => "top_level_article",
-    "embedded_forms.article" => "namespaced_article",
-    "embedded_forms.newsletter.article" => "newsletter_article",
-    "embedded_forms.newsletter.components.article" => "newsletter_components_article",
-    "embedded_forms.general.article" => "general_article",
-   }}
+    "article" => -> (*_) { "top_level_article" },
+    "embedded_forms.article" => -> (*_) { "namespaced_article" },
+    "embedded_forms.newsletter.article" => -> (*_) { "newsletter_article" },
+    "embedded_forms.newsletter.components.article" => -> (*_) { "newsletter_components_article" },
+    "embedded_forms.general.article" => -> (*_) { "general_article" },
+  }}
 
-  context "no namespace or paths configured" do
-    let(:namespace) { nil }
-    let(:paths) { [] }
+  describe "#call" do
+    context "no namespace or paths configured" do
+      let(:namespace) { nil }
+      let(:paths) { [] }
 
-    describe "#resolve_key" do
       it "returns the top level result" do
-        expect(renderer.send(:resolve_key, "article")).to eq "article"
+        expect(renderer.(name: "article")).to eq "top_level_article"
       end
     end
-  end
 
-  context "namespace configured" do
+
+    context "namespace configured" do
     let(:namespace) { "embedded_forms" }
     let(:paths) { [] }
 
-    describe "#resolve_key" do
       it "returns the namespaced result" do
-        expect(renderer.send(:resolve_key, "article")).to eq "embedded_forms.article"
+        expect(renderer.(name: "article")).to eq "namespaced_article"
       end
     end
-  end
 
   context "namespace and paths configured" do
     let(:namespace) { "embedded_forms" }
@@ -39,7 +37,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
 
     describe "#resolve_key" do
       it "returns the result in the first path" do
-        expect(renderer.send(:resolve_key, "article")).to eq "embedded_forms.newsletter.components.article"
+        expect(renderer.(name: "article")).to eq "newsletter_components_article"
       end
     end
   end
@@ -50,7 +48,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
 
     describe "#resolve_key" do
       it "returns the result in the namespace" do
-        expect(renderer.send(:resolve_key, "article")).to eq "embedded_forms.article"
+        expect(renderer.(name: "article")).to eq "namespaced_article"
       end
     end
   end
@@ -64,7 +62,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
 
     describe "#resolve_key" do
       it "does not return the result outside the namespace" do
-        expect(renderer.send(:resolve_key, "article")).to eq nil
+        expect(renderer.(name: "article")).to eq ""
       end
     end
   end


### PR DESCRIPTION
The PR adds to options to the constructor of the EmbeddedFormRenderer, `namespace` and `paths`. 

The `namespace` option simplifies setup by giving the option to let the renderer do the namespace filtering of the container, so you don't having to setup a new container class to do this. 

The paths option lets you setup form views in folders and traverse each when looking for a key. This gives us the ability to  organise the views into folders, as well as setup views for different contexts. So if, for example, there is an article template in a newsletter folder and a general folder, setting up the newsletter renderer with `paths: ["newsletter", "general"]` would resolve the template in the `newsletter` folder. But the newsletter renderer could also use the views in the `general` folder.

Note: I have also included a commit for the updated dry-validation support that was in another branch, as this was need to get the specs passing with dry-validation ~> 1.0