### PR TITLE
Support call time embedded form renderer options.

### DIFF
--- a/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
+++ b/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
@@ -14,16 +14,25 @@ module Formalist
           @options = options
         end
 
-        def call(form_data, **context_options)
+        def call(form_data)
           type, data = form_data.values_at(:name, :data)
 
           key = resolve_key(type)
 
           if key
-            container[key].(data, **(options.merge(context_options)))
+            container[key].(data, **options)
           else
             ""
           end
+        end
+
+        def with(**context_options)
+          self.class.new(
+            container,
+            namespace: namespace,
+            paths: paths,
+            **options.merge(context_options)
+          )
         end
 
         private

--- a/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
+++ b/lib/formalist/rich_text/rendering/embedded_form_renderer.rb
@@ -14,13 +14,13 @@ module Formalist
           @options = options
         end
 
-        def call(form_data)
+        def call(form_data, **context_options)
           type, data = form_data.values_at(:name, :data)
 
           key = resolve_key(type)
 
           if key
-            container[key].(data, **options)
+            container[key].(data, **(options.merge(context_options)))
           else
             ""
           end

--- a/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
+++ b/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
@@ -1,7 +1,7 @@
 require "formalist/rich_text/rendering/embedded_form_renderer"
 
 RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
-  subject(:renderer) { described_class.new(container, namespace: namespace, paths: paths) }
+  subject(:renderer) { described_class.new(container, namespace: namespace, paths: paths, **options) }
 
   let(:container) {{
     "article" => -> (*_) { "top_level_article" },
@@ -10,6 +10,12 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
     "embedded_forms.newsletter.components.article" => -> (*_) { "newsletter_components_article" },
     "embedded_forms.general.article" => -> (*_) { "general_article" },
   }}
+
+  let(:options) {
+    { render_context: "general" }
+  }
+  let(:namespace) { nil }
+  let(:paths) { [] }
 
   describe "#call" do
     context "no namespace or paths configured" do
@@ -57,6 +63,12 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       it "does not return the result outside the namespace" do
         expect(renderer.({name: "article"})).to eq ""
       end
+    end
+  end
+
+  describe "#with" do
+    it "returns an object with options merged" do
+      expect(renderer.with(context: "new").options).to eq({render_context: "general", context: "new"})
     end
   end
 end

--- a/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
+++ b/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { [] }
 
       it "returns the top level result" do
-        expect(renderer.({name: "article"})).to eq "top_level_article"
+        expect(renderer.(name: "article")).to eq "top_level_article"
       end
     end
 
@@ -33,7 +33,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { [] }
 
       it "returns the namespaced result" do
-        expect(renderer.({name: "article"})).to eq "namespaced_article"
+        expect(renderer.(name: "article")).to eq "namespaced_article"
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { ["newsletter/components", "newsletter", "general"] }
 
         it "returns the result in the first path" do
-          expect(renderer.({name: "article"})).to eq "newsletter_components_article"
+          expect(renderer.(name: "article")).to eq "newsletter_components_article"
         end
     end
 
@@ -51,7 +51,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { ["other", "path"] }
 
       it "returns the result in the namespace" do
-        expect(renderer.({name: "article"})).to eq "namespaced_article"
+        expect(renderer.(name: "article")).to eq "namespaced_article"
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:container) { { "article" => "top_level_article" } }
 
       it "does not return the result outside the namespace" do
-        expect(renderer.({name: "article"})).to eq ""
+        expect(renderer.(name: "article")).to eq ""
       end
     end
   end

--- a/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
+++ b/spec/unit/rich_text/rendering/embedded_form_renderer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { [] }
 
       it "returns the top level result" do
-        expect(renderer.(name: "article")).to eq "top_level_article"
+        expect(renderer.({name: "article"})).to eq "top_level_article"
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { [] }
 
       it "returns the namespaced result" do
-        expect(renderer.(name: "article")).to eq "namespaced_article"
+        expect(renderer.({name: "article"})).to eq "namespaced_article"
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { ["newsletter/components", "newsletter", "general"] }
 
         it "returns the result in the first path" do
-          expect(renderer.(name: "article")).to eq "newsletter_components_article"
+          expect(renderer.({name: "article"})).to eq "newsletter_components_article"
         end
     end
 
@@ -45,7 +45,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:paths) { ["other", "path"] }
 
       it "returns the result in the namespace" do
-        expect(renderer.(name: "article")).to eq "namespaced_article"
+        expect(renderer.({name: "article"})).to eq "namespaced_article"
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Formalist::RichText::Rendering::EmbeddedFormRenderer do
       let(:container) { { "article" => "top_level_article" } }
 
       it "does not return the result outside the namespace" do
-        expect(renderer.(name: "article")).to eq ""
+        expect(renderer.({name: "article"})).to eq ""
       end
     end
   end


### PR DESCRIPTION
Allow additional options to be passed to the `EmbeddedFormRenderer` after the object has been initialized.

A `#with` method has been added to `EmbeddedFormRenderer` that allows additional options to be configured. The method creates a copy of the class with the new options merged in. 

For example In our hanami app we have a context helper that renders components. This allows us to access context methods like `current_url` from our component templates by configuring it with the current context:

```component_form_renderer.with(context: self).(component_data)```
